### PR TITLE
Add support for OpenBSD

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class rclocal(
     path    => $rclocal::config_file,
     mode    => '0755',
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     content => template($rclocal::template),
   }
 
@@ -27,7 +27,7 @@ class rclocal(
     path    => $rclocal::config_dir,
     mode    => '0755',
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     purge   => true,
     recurse => true,
   }

--- a/manifests/script.pp
+++ b/manifests/script.pp
@@ -36,7 +36,7 @@ define rclocal::script (
     path    => "${rclocal::config_dir}/${priority}-${safe_name}",
     mode    => '0755',
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     require => File['/etc/rc.local.d'],
     content => $content,
   }

--- a/templates/rc.local.erb
+++ b/templates/rc.local.erb
@@ -1,4 +1,6 @@
+<% if @operatingsystem != 'OpenBSD' -%>
 #!/bin/sh -e
+<% end -%>
 # File Managed by Puppet
 #
 # This script is executed at the end of each multiuser runlevel.
@@ -7,7 +9,7 @@
 #
 # With Puppet is managed the content of <%= scope.lookupvar('rclocal::config_dir') %>
 
-for command in $(ls -v1 <%= scope.lookupvar('rclocal::config_dir') %> ) ; do
+for command in $(ls<% if @operatingsystem != 'OpenBSD' %> -v1<% end %> <%= scope.lookupvar('rclocal::config_dir') %> ) ; do
     <%= scope.lookupvar('rclocal::config_dir') %>/$command
 done
 


### PR DESCRIPTION
Before inventing the wheel myself, I just found this little module,
doing exactly what I want to do, but on OpenBSD ;).

Please consider for merge, or let me know if changes are
required to get it in.

On *BSD, there is no group called 'root', therefore just use
the GID of 0 to define the group membership of files and directories
in init.pp and script.pp.

OpenBSD just has:

[ -f /etc/rc.local ] && sh /etc/rc.local

therefore, the shell shebang is not needed here, so update the
template for that case, omitting it when running on OpenBSD.

cheers,
Sebastian