### PR TITLE
Debian uses rc-local.service, not rc.local.service

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,2 +1,0 @@
----
-rclocal::service_name: 'rc.local.service'


### PR DESCRIPTION
This PR fixes usage of this module on Debian and Ubuntu. It fixes issue #27.